### PR TITLE
fix: lint issues and handle meaningful errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -284,7 +284,7 @@ func run() error {
 	}
 	err = ssh.HostKeyFile(config.HostKeyFile)(server)
 	if err != nil {
-		return fmt.Errorf("could not to hostkey to the server: %w", err)
+		return fmt.Errorf("could not add hostkey to the server: %w", err)
 	}
 
 	slog.Info("listening", "addr", config.BindAddr)


### PR DESCRIPTION
Server couldn't function if hostkey is not loaded cause it can't sign anything:
```go
	err = ssh.HostKeyFile(config.HostKeyFile)(server)
	if err != nil {
		return fmt.Errorf("could not to hostkey to the server: %w", err)
	}
```
looks like the parser doesn't call exit on error of FailSubcommand so we should manually stop the handler:
```go
			err = parser.FailSubcommand("buffer size needs to be between 512 and 65536", "send")
			if err != nil {
				return
			}
```

I don't see meaningful handle for `s.Exit`, `io.WriteString` and `spin.Render` so just received errors to prevent lint issues.